### PR TITLE
Adding missing TIFF alias: Tif

### DIFF
--- a/src/magick-format.ts
+++ b/src/magick-format.ts
@@ -216,6 +216,7 @@ export enum MagickFormat {
     Text = 'TEXT',
     Tga = 'TGA',
     Thumbnail = 'THUMBNAIL',
+    Tif = 'TIF',
     Tiff = 'TIFF',
     Tiff64 = 'TIFF64',
     Tile = 'TILE',


### PR DESCRIPTION
Feel free to let me know if I've misunderstood anything; it looks to me like `magick-format.ts` is meant to have all formats, including aliases?

If we look at the source during the 7.0.10-25 release, it also had an alias for `TIFF` called `TIF` to open `.tif` files.
> ```cpp
> #define MagickTIFFAliases \
>   MagickCoderAlias("TIFF", "GROUP4") \
>   MagickCoderAlias("TIFF", "PTIF") \
>   MagickCoderAlias("TIFF", "TIF") \
>   MagickCoderAlias("TIFF", "TIFF64")
> ```
> https://github.com/ImageMagick/ImageMagick/blob/8b4e00829eb84d4e7b4da11acf1f98f1e8166e5b/coders/tiff.h

The enum currently only has `GROUP4`, `PTIF`, `TIFF`, and `TIFF64`, but not `TIF`.

---

On the side, just want to say thank you for all the work you've done on ImageMagick/Magick.NET/Magick.WASM. <3